### PR TITLE
resolve an ambiguity

### DIFF
--- a/src/quasifill.jl
+++ b/src/quasifill.jl
@@ -261,9 +261,9 @@ sum(x::AbstractQuasiFill) = getindex_value(x)*measure(axes(x,1))
 sum(x::QuasiZeros) = getindex_value(x)
 
 # define `sum(::Callable, ::AbstractQuasiFill)` to avoid method ambiguity errors on Julia 1.0
-sum(f, x::AbstractQuasiFill) = _sum(f, x)
-sum(f::Base.Callable, x::AbstractQuasiFill) = _sum(f, x)
-_sum(f, x::AbstractQuasiFill) = measure(x) * f(getindex_value(x))
+sum(f, x::AbstractQuasiFill) = _sum(f, x, :)
+sum(f::Base.Callable, x::AbstractQuasiFill) = _sum(f, x, :)
+_sum(f, x::AbstractQuasiFill, ::Colon) = measure(x) * f(getindex_value(x))
 
 
 #########


### PR DESCRIPTION
Apparently `Base._sum` must accept a `dim` argument, otherwise `_sum(f, A::something)` and `_sum(A::something, dim)` technically introduce an ambiguity.