### PR TITLE
Added import Base: isassigned so that view works correctly on QuasiAr…

### DIFF
--- a/src/QuasiArrays.jl
+++ b/src/QuasiArrays.jl
@@ -16,7 +16,7 @@ import Base: Slice, IdentityUnitRange, ScalarIndex, RangeIndex, view, viewindexi
                 parentindices, reverse, ndims, checkbounds, uncolon,
                 maybeview, unsafe_view, checkindex, checkbounds_indices,
                 throw_boundserror, rdims, replace_in_print_matrix, show, summary,
-                hcat, vcat, hvcat
+                hcat, vcat, hvcat, isassigned
 import Base: *, /, \, +, -, ^, inv
 import Base: exp, log, sqrt,
           cos, sin, tan, csc, sec, cot,


### PR DESCRIPTION
Currently, the following fails with a missing method

```
    using QuasiArrays
    A = QuasiArray(randn(5,2), (0:0.5:2, [1,4]))
    V = view(A, 0.0, [1,4])
```

This PR just adds that import to QuasiArrays.jl.  There is a test for this in test_quasipermutedims and it does pass, but fails
outside of the test environment.