### PR TITLE
Reattach the docstring for `QuasiCartesianIndices`

### DIFF
--- a/src/multidimensional.jl
+++ b/src/multidimensional.jl
@@ -243,7 +243,6 @@ module QuasiIteratorsMD
 
     For cartesian to linear index conversion, see [`LinearIndices`](@ref).
     """
-
     struct QuasiCartesianIndices{N,R<:NTuple{N,AbstractQuasiOrVector},RR<:NTuple{N,Any}} <: AbstractArray{QuasiCartesianIndex{N,RR},N}
         indices::R
     end


### PR DESCRIPTION
This is a trivial documentation issue. A blank line sits between the docstring and `struct QuasiCartesianIndices`, so the docstring is never attached.

```julia
julia> using QuasiArrays   # v0.13.10

julia> M = QuasiArrays.QuasiIteratorsMD;

julia> haskey(Base.Docs.meta(M), Base.Docs.Binding(M, :QuasiCartesianIndices))
false
```

Removing the blank line restores it. Julia binds a string literal to the *immediately* following expression, and the manual notes that no blank lines or comments may intervene.
